### PR TITLE
Refactor AppLandingPage to fetch download URL from backend API

### DIFF
--- a/back-end/app/routes/app_info.py
+++ b/back-end/app/routes/app_info.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, jsonify
+import requests
+
+blueprint = Blueprint('app_info', __name__, url_prefix='/api/app')
+
+FIRESTORE_URL = 'https://firestore.googleapis.com/v1/projects/svitlo-power/databases/(default)/documents/sites/app'
+
+@blueprint.route('/info', methods=['GET'])
+def get_app_info():
+    try:
+        response = requests.get(FIRESTORE_URL, timeout=10)
+        response.raise_for_status()
+        
+        data = response.json()
+        
+        fields = data.get('fields', {})
+        
+        update_url = fields.get('updateUrl', {}).get('stringValue', '')
+        version = fields.get('ver', {}).get('stringValue', '')
+        
+        return jsonify({
+            'updateUrl': update_url,
+            'version': version
+        }), 200
+        
+    except requests.exceptions.RequestException as e:
+        return jsonify({
+            'error': 'Failed to fetch app information',
+            'message': str(e)
+        }), 500
+    except Exception as e:
+        return jsonify({
+            'error': 'Internal server error',
+            'message': str(e)
+        }), 500
+
+
+def register(app, services):
+    app.register_blueprint(blueprint)
+

--- a/front-end/src/pages/public/appLanding.tsx
+++ b/front-end/src/pages/public/appLanding.tsx
@@ -41,25 +41,22 @@ export const AppLandingPage = () => {
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentImageIndex((prevIndex) => (prevIndex + 1) % appImages.length);
-    }, 3000); // Change image every 3 seconds
+    }, 3000); 
 
     return () => clearInterval(interval);
   }, [appImages.length]);
 
   useEffect(() => {
-    // Fetch download URL from Firestore
     const fetchDownloadUrl = async () => {
       try {
-        const response = await fetch(
-          'https://firestore.googleapis.com/v1/projects/svitlo-power/databases/(default)/documents/sites/app'
-        );
+        const response = await fetch('/api/app/info');
         const data = await response.json();
         
-        if (data.fields?.updateUrl?.stringValue) {
-          setDownloadUrl(data.fields.updateUrl.stringValue);
+        if (data.updateUrl) {
+          setDownloadUrl(data.updateUrl);
         }
-        if (data.fields?.ver?.stringValue) {
-          setAppVersion(data.fields.ver.stringValue);
+        if (data.version) {
+          setAppVersion(data.version);
         }
       } catch (error) {
         console.error('Failed to fetch download URL:', error);


### PR DESCRIPTION
- Updated the download URL fetching method to use the backend API instead of Firestore.
- Simplified the response handling by directly accessing the properties for updateUrl and version.